### PR TITLE
hotfix - conditionally add social icons based on _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,14 +22,14 @@ image_alt: A minimalistic jekyll theme for academic    # image description
 author: John Doe 
 profile_image: /assets/img/avatar/cropped.png #/assets/img/avatar/avatar.jpeg 
 occupation: 
-snippet: 
+snippet:
 twitter: tbutler0x90
 github: tcbutler320
 linkedin: tyler-b-a700a1aa
-stackoverflow: 12935605
+stackoverflow: '12935605'
 website: https://tbutler.org
-codepen: tcbutler320
-medium: tbutler0x90
+codepen: 
+medium: 
 email: developer.tbutler@gmail.com
 keybase: tbutler320
 pgp: 

--- a/_data/themes.yml
+++ b/_data/themes.yml
@@ -31,6 +31,7 @@ abyss:
     post-author-size: "15px"
     post-font-weight: "700"
     default-button-color: ""
+    social-color-footer : black
 
 dark: 
     name: dark
@@ -69,5 +70,7 @@ dark:
     post-author-size: "15px"
     post-font-weight: "700"
     default-button-color: ""
+    social-color-footer : black
+
 
 

--- a/_includes/social-footer.html
+++ b/_includes/social-footer.html
@@ -1,30 +1,47 @@
 <!-- Displays Social Media Icons based on _config.yml settings -->
 {{ if site.twitter }}
 <span style="color: Black;">
-    <i> &nbsp;&nbsp; </i>
+     {% if site.twitter %}
         <a class="social-link" href="https://twitter.com/{{ site.twitter }}">
-            <span style="color: Black;">
-                <i class="fab fa-twitter-square fa-lg"></i></a>
-            </span>
-    {{ elseif site.github }}
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-twitter-square fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.github %}
         <a href="https://github.com/{{ site.github }}">
-            <span style="color: Black;">
+        <span style="color: {{ theme.social-color-footer }};">
             <i class="fab fa-github-square fa-lg"></i></a>
         </span>
-    {{ elseif site.linkedin }}
+    {% endif %}
+    {% if site.linkedin %}
         <a href="https://www.linkedin.com/in/{{ site.linkedin }}">
-            <span style="color: Black;">
-                <i class="fab fa-linkedin fa-lg"></i></a>
-            </span>
-    {{ elseif site.codepen }}
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-linkedin fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.codepen %}
         <a href="https://codepen.io/{{ site.codepen }}">
-            <span style="color: Black;">
-                <i class="fab fa-codepen fa-lg"></i></a>
-            </span>
-    {{ elseif site.stackoverflow }}
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-codepen fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.stackoverflow %}
         <a href="https://stackoverflow.com/users/story/{{ site.stackoverflow }}">
-            <span style="color: Black;">
-                <i class="fab fa-stack-overflow fa-lg"></i></a>
-            </span>
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-stack-overflow fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.medium %}
+        <a href="https://{{ site.medium }}.medium.com/">
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-medium fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.keybase %}
+        <a href="https://keybase.io/{{ site.keybase }}">
+        <span style="color: {{ theme.social-color-footer }};">
+            <i class="fab fa-keybase"></i></a>
+        </span>
+    {% endif %} 
     <i> &nbsp;&nbsp; </i>
 </span>

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,41 +1,48 @@
 {% assign theme = site.data.themes[site.ui_theme] %}
 <!-- Displays Social Media Icons based on _config.yml settings -->
-{{ if site.twitter }}
 <span style="color:{{ theme.social-color }};">
     <i> &nbsp;&nbsp; </i>
+    {% if site.twitter %}
         <a class="social-link" href="https://twitter.com/{{ site.twitter }}">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-twitter-square fa-lg"></i></a>
-            </span>
-    {{ elseif site.github }}
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-twitter-square fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.github %}
         <a href="https://github.com/{{ site.github }}">
-            <span style="color: {{ theme.social-color }};">
+        <span style="color: {{ theme.social-color }};">
             <i class="fab fa-github-square fa-lg"></i></a>
         </span>
-    {{ elseif site.linkedin }}
+    {% endif %}
+    {% if site.linkedin %}
         <a href="https://www.linkedin.com/in/{{ site.linkedin }}">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-linkedin fa-lg"></i></a>
-            </span>
-    {{ elseif site.codepen }}
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-linkedin fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.codepen %}
         <a href="https://codepen.io/{{ site.codepen }}">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-codepen fa-lg"></i></a>
-            </span>
-    {{ elseif site.stackoverflow }}
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-codepen fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.stackoverflow %}
         <a href="https://stackoverflow.com/users/story/{{ site.stackoverflow }}">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-stack-overflow fa-lg"></i></a>
-            </span>
-    {{ elseif site.medium }}
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-stack-overflow fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.medium %}
         <a href="https://{{ site.medium }}.medium.com/">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-medium fa-lg"></i></a>
-            </span>
-    {{ elseif site.keybase }}
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-medium fa-lg"></i></a>
+        </span>
+    {% endif %}
+    {% if site.keybase %}
         <a href="https://keybase.io/{{ site.keybase }}">
-            <span style="color: {{ theme.social-color }};">
-                <i class="fab fa-keybase"></i></a>
-            </span>
+        <span style="color: {{ theme.social-color }};">
+            <i class="fab fa-keybase"></i></a>
+        </span>
+    {% endif %} 
     <i> &nbsp;&nbsp; </i>
 </span>


### PR DESCRIPTION
This hotfix addresses a recent issue raised in the [discussions](https://github.com/tcbutler320/Jekyll-Theme-Dumbarton/discussions/52). Previously, if you only wanted to use a subset of the available social icons in the navbar, all of the icons would still appear even if you left some intentionally blank in `_config.yml`. 

This was caused by error in conditional syntax in social.html and social-footer.htm. The fix adds conditional handling, so that an empty social in `_config.yml` removes the corresponding social icon from the nav bar.

The fix uses a set of if, then, end clauses. It intentionally does not use the if, else if, else if .... end clause because of an unknown issue ( this will eventually be fixed).

```html
   {% if site.twitter %}
        <a class="social-link" href="https://twitter.com/{{ site.twitter }}">
        <span style="color: {{ theme.social-color-footer }};">
            <i class="fab fa-twitter-square fa-lg"></i></a>
        </span>
    {% endif %}
    {% if site.github %}
        <a href="https://github.com/{{ site.github }}">
        <span style="color: {{ theme.social-color-footer }};">
            <i class="fab fa-github-square fa-lg"></i></a>
        </span>
    {% endif %}
```